### PR TITLE
Fix bug when same style `url(/path/to/logo.png)` in invalid CSS

### DIFF
--- a/src/lib/scraper.js
+++ b/src/lib/scraper.js
@@ -86,7 +86,7 @@ class Scraper {
                     let relative = str.replace(/url\("?'?([^'")]+)"?'?\)/, '$1');
                     if (relative && url.resolve(this.config.targetHost, relative).match(this.config.targetHost)) {
                         let absolute = url.resolve(this.config.targetHost + path, relative).replace(this.config.targetHost,'');
-                        cssStr = cssStr.replace(relative, absolute);
+                        cssStr = cssStr.replace(new RegExp(`([\("'])${relative}([\)"'])`), `$1${absolute}$2`);
                         links.push(this.utsusemi.realPath(absolute));
                     }
                 });

--- a/test/fixtures/invalid_with_url.css
+++ b/test/fixtures/invalid_with_url.css
@@ -42,3 +42,11 @@ div.logo {
 div.title {
     background: url(../img/title.png);
 }
+
+div.same1 {
+    background: url('img/same.png');
+}
+
+div.same2 {
+    background: url('img/same.png');
+}

--- a/test/fixtures/valid_with_url.css
+++ b/test/fixtures/valid_with_url.css
@@ -100,3 +100,11 @@ div.logo {
 div.title {
     background: url(../img/title.png);
 }
+
+div.same1 {
+    background: url('img/same.png');
+}
+
+div.same2 {
+    background: url('img/same.png');
+}

--- a/test/scraper.test.js
+++ b/test/scraper.test.js
@@ -58,7 +58,9 @@ describe('scraper.scrapeCSS()', () => {
         const scraped = scraper.scrapeCSS(cssStr, path);
         assert(scraped[0].match('/img/logo.png'));
         assert(scraped[0].match('/path/img/title.png'));
-        assert(scraped[1].toString() === ['/img/logo.png', '/path/img/title.png'].toString());
+        assert(scraped[0].match('/path/to/img/same.png'));
+        assert(!scraped[0].match(/'img\/same\.png'/));
+        assert(scraped[1].toString() === ['/img/logo.png', '/path/img/title.png', '/path/to/img/same.png'].toString());
     });
     it ('Scrape valid CSS with `@import`', () => {
         const cssStr = fs.readFileSync(__dirname + '/fixtures/valid_with_import.css', 'utf8');
@@ -102,7 +104,9 @@ describe('scraper.scrapeCSS()', () => {
         const scraped = scraper.scrapeCSS(cssStr, path);
         assert(scraped[0].match('/img/logo.png'));
         assert(scraped[0].match('/path/img/title.png'));
-        assert(scraped[1].toString() === ['/img/logo.png', '/path/img/title.png'].toString());
+        assert(scraped[0].match('/path/to/img/same.png'));
+        assert(!scraped[0].match(/'img\/same\.png'/));
+        assert(scraped[1].toString() === ['/img/logo.png', '/path/img/title.png', '/path/to/img/same.png'].toString());
     });
     it ('Scrape invalid CSS with `@import`', () => {
         const cssStr = fs.readFileSync(__dirname + '/fixtures/invalid_with_import.css', 'utf8');


### PR DESCRIPTION
```css
div.same1 {
    background: url('img/same.png');
}

div.same2 {
    background: url('img/same.png');
}
```